### PR TITLE
Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://github.com/vivainio/pickleshare
 
 Package license: MIT
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: Tiny 'shelve'-like database with concurrency support
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.1" %}
+{% set version = "0.7.2" %}
 
 package:
   name: pickleshare
@@ -7,7 +7,7 @@ package:
 source:
   fn: pickleshare-{{ version }}.tar.gz
   url: https://pypi.python.org/packages/source/p/pickleshare/pickleshare-{{ version }}.tar.gz
-  md5: d039ea7dc706180fc4b7953da3bcb3cb
+  md5: 29d74cde0255546b6b2e1b48a0b31a54
 
 build:
   number: 0


### PR DESCRIPTION
Re-rendered the feedstock and updated `pickleshare` to `0.7.2`.
